### PR TITLE
Fully removed camera/slsdetector

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -54,7 +54,7 @@
 	url = git://github.com/soleil-ica/Lima-camera-eiger
 [submodule "applications/tango/cpp"]
 	path = applications/tango/cpp
-	url = git://github.com/soleil-ica/Lima-tango-cpp
+	url = git://github.com/hott-onin/Lima-tango-cpp
 [submodule "camera/slsjungfrau"]
 	path = camera/slsjungfrau
 	url = git://github.com/soleil-ica/Lima-camera-slsjungfrau.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -54,7 +54,7 @@
 	url = git://github.com/soleil-ica/Lima-camera-eiger
 [submodule "applications/tango/cpp"]
 	path = applications/tango/cpp
-	url = git://github.com/hott-onin/Lima-tango-cpp
+	url = git://github.com/soleil-ica/Lima-tango-cpp
 [submodule "camera/slsjungfrau"]
 	path = camera/slsjungfrau
 	url = git://github.com/soleil-ica/Lima-camera-slsjungfrau.git


### PR DESCRIPTION
There was still a camera/slsdetector folder, as an entry in mode "160000", a special entry in the Git index.

This was causing the error _"Unable to checkout 'a813713df268ad105cb1f39c7cbc0ce53a104523' in submodule path 'camera/slsdetector"_

Solved by removing the special entry manually with git rm.

Information: all those special entries can be listed with the command _git ls-files --stage | grep 160000_
